### PR TITLE
fix(ssr): use serverApiClient for authenticated server page data fetches

### DIFF
--- a/src/app/[labId]/animals/[id]/measurements/new/page.tsx
+++ b/src/app/[labId]/animals/[id]/measurements/new/page.tsx
@@ -1,6 +1,6 @@
 import type { AnimalRecord, AnimalRecordMeasurement } from "../../types";
 import MeasurementsContainer from "./measurements.container";
-import { apiClient } from "@/src/lib/apiClient";
+import { serverApiClient } from "@/src/lib/serverApiClient";
 import type { PageProps } from "./types";
 import { getServerAuthenticatedUserId } from "@/src/lib/serverUserId";
 
@@ -12,8 +12,8 @@ export default async function Page({ params, searchParams }: PageProps) {
 
   const rows = 100;
   const page = 1;
-  const animal = await apiClient.get(`/api/animals/animal/${userId}/${labId}/${animalId}/${rows}/${page}`);
-  const animalEnums = await apiClient.get(`/api/animals/enums`);
+  const animal = await serverApiClient.get(`/api/animals/animal/${userId}/${labId}/${animalId}/${rows}/${page}`);
+  const animalEnums = await serverApiClient.get(`/api/animals/enums`);
   const measurements = animal.data.records.map((record: AnimalRecord) => record.measurements);
 
   const uniqueMeasurements = measurements.flat().reduce((acc: AnimalRecordMeasurement[], current: AnimalRecordMeasurement) => {

--- a/src/app/[labId]/animals/[id]/page.tsx
+++ b/src/app/[labId]/animals/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use server"
 
 import RecordContainer from "./record.container";
-import { apiClient } from "@/src/lib/apiClient";
+import { serverApiClient } from "@/src/lib/serverApiClient";
 import type { PageProps } from "./types";
 import { getServerAuthenticatedUserId } from "@/src/lib/serverUserId";
 
@@ -10,7 +10,7 @@ export default async function RecordPage({params}: PageProps) {
     const userId = await getServerAuthenticatedUserId()
     const rows = 10;
     const page = 1;
-    const animal = await apiClient.get(`/api/animals/animal/${userId}/${labId}/${animalId}/${rows}/${page}`);
+    const animal = await serverApiClient.get(`/api/animals/animal/${userId}/${labId}/${animalId}/${rows}/${page}`);
     return (
         <RecordContainer
             animalPagination={animal.pagination}

--- a/src/app/[labId]/animals/page.tsx
+++ b/src/app/[labId]/animals/page.tsx
@@ -1,7 +1,7 @@
 "use server"
 
 import AnimalContainer from "./animal.container";
-import { apiClient } from "@/src/lib/apiClient";
+import { serverApiClient } from "@/src/lib/serverApiClient";
 import type { PageProps } from "./types";
 import { getServerAuthenticatedUserId } from "@/src/lib/serverUserId";
 
@@ -12,9 +12,9 @@ export default async function AnimalsPage({params}: PageProps) {
   const rows = 10;
   const page = 1;
 
-  const animals = await apiClient.get(`/api/animals/${userId}/${labId}/${rows}/${page}/${JSON.stringify({})}`);
-  const animalTypes = await apiClient.get(`/api/animals/types/${userId}/${labId}`);
-  const animalEnums = await apiClient.get(`/api/animals/enums`);
+  const animals = await serverApiClient.get(`/api/animals/${userId}/${labId}/${rows}/${page}/${JSON.stringify({})}`);
+  const animalTypes = await serverApiClient.get(`/api/animals/types/${userId}/${labId}`);
+  const animalEnums = await serverApiClient.get(`/api/animals/enums`);
 
   return (
     <AnimalContainer

--- a/src/app/[labId]/dashboard/page.tsx
+++ b/src/app/[labId]/dashboard/page.tsx
@@ -1,7 +1,7 @@
 "use server"
 
 import DashboardContainer from "./deshboard.container";
-import { apiClient } from "@/src/lib/apiClient";
+import { serverApiClient } from "@/src/lib/serverApiClient";
 import type { PageProps } from "./types";
 import { getServerAuthenticatedUserId } from "@/src/lib/serverUserId";
 
@@ -9,9 +9,9 @@ export default async function Page ({params}: PageProps) {
   const {labId} = await params;
   const userId = await getServerAuthenticatedUserId()
 
-  const animals = await apiClient.get(`/api/animals/${userId}/${labId}/999999/1/${JSON.stringify({})}`);
-  const experiments = await apiClient.get(`/api/experiments/${userId}/${labId}`);
-  const tasks = await apiClient.get(`/api/tasks/${userId}/${labId}`);
+  const animals = await serverApiClient.get(`/api/animals/${userId}/${labId}/999999/1/${JSON.stringify({})}`);
+  const experiments = await serverApiClient.get(`/api/experiments/${userId}/${labId}`);
+  const tasks = await serverApiClient.get(`/api/tasks/${userId}/${labId}`);
 
   return (
     <DashboardContainer 

--- a/src/app/[labId]/experiments/[id]/page.tsx
+++ b/src/app/[labId]/experiments/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import type { ExperimentAnimalRecordRow, ExperimentMetricsData, ExperimentTasksPagePayload } from "../types";
 import { ExperimentContainer } from "./experiment.container";
-import { apiClient } from "@/src/lib/apiClient";
+import { serverApiClient } from "@/src/lib/serverApiClient";
 import { getServerAuthenticatedUserId } from "@/src/lib/serverUserId";
 interface ExperimentDetailPageProps {
   params: Promise<{
@@ -24,18 +24,18 @@ export default async function ExperimentDetailPage({ params }: ExperimentDetailP
     recordsRes,
     experimentTasksRes,
   ] = await Promise.all([
-    apiClient.get(`/api/experiments/unique/${userId}/${labId}/${experimentId}`),
-    apiClient.get(`/api/laboratory/${userId}/${labId}`),
-    apiClient.get(
+    serverApiClient.get(`/api/experiments/unique/${userId}/${labId}/${experimentId}`),
+    serverApiClient.get(`/api/laboratory/${userId}/${labId}`),
+    serverApiClient.get(
       `/api/animals/${userId}/${labId}/${labAnimalsRows}/${labAnimalsPage}/${JSON.stringify({})}`,
     ),
-    apiClient.get(`/api/experiments/unique/${userId}/${labId}/${experimentId}/metrics`).catch(() => ({
+    serverApiClient.get(`/api/experiments/unique/${userId}/${labId}/${experimentId}/metrics`).catch(() => ({
       success: false as const,
     })),
-    apiClient
+    serverApiClient
       .get(`/api/experiments/unique/${userId}/${labId}/${experimentId}/records?limit=200`)
       .catch(() => ({ success: false as const })),
-    apiClient
+    serverApiClient
       .get(
         `/api/experiments/unique/${userId}/${labId}/${experimentId}/tasks?page=1&pageSize=${initialTasksPageSize}`,
       )

--- a/src/app/[labId]/experiments/page.tsx
+++ b/src/app/[labId]/experiments/page.tsx
@@ -1,7 +1,7 @@
 "use server"
 
 import ExperimentsContainer from "./experiments.container"
-import { apiClient } from "@/src/lib/apiClient"
+import { serverApiClient } from "@/src/lib/serverApiClient"
 import { getServerAuthenticatedUserId } from "@/src/lib/serverUserId"
 interface ExperimentsTypes {
   params: {
@@ -12,8 +12,8 @@ interface ExperimentsTypes {
 export default async function ExperimentsPage({params}: ExperimentsTypes) {
   const { labId } = await params;
   const userId = await getServerAuthenticatedUserId()
-  const animalEnums = await apiClient.get(`/api/animals/enums`);
-  const experiments = await apiClient.get(`/api/experiments/${userId}/${labId}`);
+  const animalEnums = await serverApiClient.get(`/api/animals/enums`);
+  const experiments = await serverApiClient.get(`/api/experiments/${userId}/${labId}`);
 
   return (
     <ExperimentsContainer

--- a/src/app/[labId]/team/page.tsx
+++ b/src/app/[labId]/team/page.tsx
@@ -1,6 +1,6 @@
 "use server"
 
-import { apiClient } from "@/src/lib/apiClient";
+import { serverApiClient } from "@/src/lib/serverApiClient";
 import TeamContainer from "./team.container";
 import { getServerAuthenticatedUserId } from "@/src/lib/serverUserId";
 interface TeamPageTypes {
@@ -12,8 +12,8 @@ interface TeamPageTypes {
 export default async function TeamPage({params}: TeamPageTypes) {
   const { labId } = await params;
   const userId = await getServerAuthenticatedUserId()
-  const animalEnums = await apiClient.get(`/api/animals/enums`);
-  const laboratoryMembers = await apiClient.get(`/api/laboratory/${userId}/${labId}`);
+  const animalEnums = await serverApiClient.get(`/api/animals/enums`);
+  const laboratoryMembers = await serverApiClient.get(`/api/laboratory/${userId}/${labId}`);
 
   return (
     <TeamContainer

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -1,12 +1,12 @@
 "use server";
 
 import LaboratoriesContainer from "./labs.container";
-import { apiClient } from "@/src/lib/apiClient";
+import { serverApiClient } from "@/src/lib/serverApiClient";
 import { getServerAuthenticatedUserId } from "@/src/lib/serverUserId";
 
 export default async function Page() {
     const userId = await getServerAuthenticatedUserId()
-    const laboratories = await apiClient.get(`/api/laboratories/${userId}`);
+    const laboratories = await serverApiClient.get(`/api/laboratories/${userId}`);
     return (
         <LaboratoriesContainer
             userLaboratories={laboratories.data}


### PR DESCRIPTION
Server Components called apiClient, which reads the JWT via js-cookie (AuthService.getToken) and only works in the browser. RSC requests sent no Authorization header, breaking SSR/API calls after the user-id header fix.

Replace with serverApiClient (cookies() auth-token) on all affected pages.